### PR TITLE
Fix an apparent typo in the default CSS style.

### DIFF
--- a/site/templates/style.css
+++ b/site/templates/style.css
@@ -17,7 +17,7 @@ body {
 .headerTitle { font-size: 1.6em; font-weight: bold; margin: 0 0 0 0.5em; padding: 0.5em; }
 .headerTitle a { border: 0; text-decoration: none; }
 
-.headerSubtitle { font-weight: normal; margin-left: 1em; }
+.headerSubtitle { font-size: 0.75em; font-weight: normal; margin-left: 1em; }
 
 /* Side */
 /* modified from sw original by jrick (jrick.devio.us) */


### PR DESCRIPTION
Due to a capitalisation mismatch between the style and the header template, the "headerSubTitle"/"headerSubtitle" style was never used.

Re-matching the capitalisation (I made the admittedly arbitrary choice in favor of the lowercase "t".), and thereby causing the style to actually be used, produced what I thought was a somewhat jarring typographical effect in the header. This was solved by commenting-out the font-size setting from the headerSubtitle style. Hopefully, the subtitle is visible yet clearly subordinate to, and clearly separate from, the title.
