### PR TITLE
proposed way to deal with external links in templates

### DIFF
--- a/rawk
+++ b/rawk
@@ -58,10 +58,15 @@ rawk_submenu() {
     file_list="$(echo \"$file_list\" | sort | xargs)"
     for file in $file_list
     do
-        printf "\n <a href=\"$(basename $file | sed -e 's/\.md$/\.html/g')\">"
+        if echo $file | grep -q '.link$'; then
+            printf "\n <a href=\"$(cat ${1%/*}/$file)\">"
+        else
+            printf "\n <a href=\"$(basename $file | sed -e 's/\.md$/\.html/g')\">"
+        fi
         printf "$(basename $file | sed -e 's/\(..*\)\.[[:alnum:]]*/\1/')"
         printf "</a> "
     done
+
     printf "\n</div>\n"
 }
 
@@ -121,6 +126,13 @@ rawk_main () {
         out_f="$(echo $src_f | sed -e 's/\([[:alnum:]]*\)\.[mM][dD]/\1/').html"
         echo "* $src_f -> $out_f"
         rawk_page $src_f > $out_f
+        rm $src_f
+    done
+
+    # don't convert external links
+    # just delete them from the build directory
+    for src_f in $(find . -iname \*.link -print | xargs)
+    do
         rm $src_f
     done
 }


### PR DESCRIPTION
I found I needed to add a few external links to my site's header.

One solution would be editing the header template. However, this would add the link to *all* pages, instead of pages in a single directory (my goal).

This is the way I did it.

Instead of creating a .md file, you create a .link file, containing the URL of the page you want to link to, for example, if I wanted to link to floof, I could create a file called `floof.link` containing the text `https://www.reddit.com/r/floof`

This would result in the following HTML:

    <a href="https://www.reddit.com/r/floof">floof</a>

For a more real-world example, if you had a personal site containing a set of tutorials, you might have a subdirectory for these tutorials. It might not make sense to link to your twitter account inside this subdirectory, but it would make sense on the main pages of the site.

What do you think? Is this too much of a specific change?